### PR TITLE
Various changes regarding Docker

### DIFF
--- a/.devcontainer/.bashrc
+++ b/.devcontainer/.bashrc
@@ -78,4 +78,4 @@ fi
 LS_COLORS='di=1;34:fi=92:ln=31:pi=96:so=96:bd=96:cd=96:or=31:mi=96:ex=33:*.rpm=90'
 export LS_COLORS
 
-export PS1="\[\e[33m\]\n\u@\[$CNX\]\h \[\e[32m\]\W \[\e[m\]\\n\$ "
+export PS1="\[\e[33m\]\u@\[$CNX\]\h \[\e[32m\]\W \[\e[m\]\\n\$ "

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -69,3 +69,6 @@ RUN python3 -m venv --system-site-packages ./venv \
     && pip install --no-cache-dir control
 
 RUN echo -e "\nsource /home/$USER/venv/bin/activate\n" >> /home/$USER/.bashrc
+
+# Remove GTK accessibility bridge triggering warnings
+ENV NO_AT_BRIDGE=1

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,68 @@
-FROM nowox/latex:3.0
+FROM ubuntu:24.04
 
-# USER $USERNAME
-# ENV USER=${USERNAME}
-# RUN useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
-# RUN groupadd --gid $USER_GID $USERNAME
-# RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
-# RUn chmod 0440 /etc/sudoers.d/$USERNAME
+RUN apt-get update && apt-get install -y --no-install-recommends locales \
+    && rm -rf /var/lib/apt/lists/* \
+	&& localedef -i fr_CH -c -f UTF-8 -A /usr/share/locale/locale.alias fr_CH.UTF-8
+ENV LANG=fr_CH.UTF-8
 
-# Bind bashrc
-# ADD .bashrc /root/.bashrc
-# ADD .bashrc /home/${USERNAME}/.bashrc
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install TeX Live without documentation and language support
+# src: https://gist.github.com/wkrea/b91e3d14f35d741cf6b05e57dfad8faf
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    $( \
+        apt-cache depends texlive-full | \
+        awk '/Depends:/{print $2}' | \
+        grep -vP 'doc$' | \
+        grep -vP 'texlive-lang' | \
+        grep -vP 'latex-cjk' | \
+        tr '\n' ' ' \
+    ) \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install selected Tex Live languages support
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    texlive-lang-french \
+    texlive-lang-english \
+    texlive-lang-european \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    make \
+    wget \
+    xvfb \
+    python3 \
+    python3-pip \
+    python3-venv \
+    python3-pygments \
+    inkscape \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://github.com/jgraph/drawio-desktop/releases/download/v26.0.9/drawio-amd64-26.0.9.deb \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    ./drawio*.deb \
+    alsa-utils \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm ./drawio*.deb
+
+# Use the existing main user
+ENV USER="ubuntu"
+
+# Add `sudo` without password
+RUN apt-get update && apt-get install -y --no-install-recommends sudo \
+    && echo "$USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USER \
+    && chmod 0440 /etc/sudoers.d/$USER \
+    && rm -rf /var/lib/apt/lists/*
+
+USER $USER
+WORKDIR /home/$USER
+
+RUN python3 -m venv --system-site-packages ./venv \
+    && source ./venv/bin/activate \
+    && pip install --no-cache-dir control
+
+RUN echo -e "\nsource /home/$USER/venv/bin/activate\n" >> /home/$USER/.bashrc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -58,6 +58,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends sudo \
     && chmod 0440 /etc/sudoers.d/$USER \
     && rm -rf /var/lib/apt/lists/*
 
+COPY ./.bashrc /home/$USER/.bashrc
+RUN chown $USER:$USER /home/$USER/.bashrc
+
 USER $USER
 WORKDIR /home/$USER
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,6 +19,7 @@
                 }
             },
             "extensions": [
+                "ms-python.python",
                 "james-yu.latex-workshop",
                 "eamodio.gitlens",
                 "stkb.rewrap",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,6 @@
     "customizations": {
         "vscode": {
             "settings": {
-                "files.eol": "\n",
                 "latex-workshop.chktex.enabled": true,
                 "latex-workshop.latex.clean.subfolder.enabled": true,
                 "latex-workshop.latex.autoClean.run": "onBuilt",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,6 @@
             "extensions": [
                 "james-yu.latex-workshop",
                 "eamodio.gitlens",
-                "shardulm94.trailing-spaces",
                 "stkb.rewrap",
                 "vscode-icons-team.vscode-icons",
                 "hediet.vscode-drawio",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+    "files.trimTrailingWhitespace": true,
+    "files.trimFinalNewlines": true,
+    "files.insertFinalNewline": true,
     "latex-workshop.latex.external.build.command": "make",
     "latex-workshop.latex.outDir": "./build",
     "files.eol": "\n",

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ all: $(OUT).tex $(FIGS) | $(BUILDDIR)
 figures: $(FIGS)
 
 $(FIGS_SVG): $(BUILDDIR)/%.svg.pdf: %.svg | dirs
-	dbus-run-session inkscape --export-area-drawing -o $@ $<
+	$(INKSCAPE) --export-area-drawing -o $@ $<
 
 $(FIGS_PY): $(BUILDDIR)/%.py.pdf: %.py | dirs
 	python3 $< > $@

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Ce référentiel contient un modèle de document LaTeX pour la production d'un r
 - [Comment démarrer / Quick Start](#comment-démarrer--quick-start)
 - [Utilisation](#utilisation)
 - [VsCode + Docker + LaTeX Suite](#vscode--docker--latex-suite)
-  - [Fork et Clone du référentiel](#fork-et-clone-du-référentiel)
-  - [Demarrer vscode](#demarrer-vscode)
+  - [Copie du référentiel](#copie-du-référentiel)
+  - [Démarrer vscode](#démarrer-vscode)
   - [Compiler](#compiler)
   - [Nettoyer la base de code](#nettoyer-la-base-de-code)
   - [Git ?](#git-)
@@ -77,11 +77,11 @@ D'autres commandes existent et sont accessibles [ici](https://cheatography.com/j
 
 L'éditeur de PDF [Sumatra](https://www.sumatrapdfreader.org/) est conseillé pour visualiser votre rapport, contrairement à Adobe Acrobat, le contenu est automatiquement rafraichi une fois le rapport recompilé.
 
-### Fork et Clone du référentiel
+### Copie du référentiel
 
-Pour bien démarrer, commencez par faire un *fork* du référentiel en cliquant sur le bouton **Fork** depuis l'interface GitHub. Ceci vous crée une copie du modèle dans votre propre organisation GitHub. Clonez ensuite le référentiel avec `git clone`.
+Pour créer votre propre référentiel à partir de celui-ci, allez sur la page https://github.com/new/import et entrez y son URL. Clonez ensuite votre nouveau référentiel avec `git clone`. Ceci vous crée une copie du modèle dans votre propre compte GitHub.
 
-### Demarrer vscode
+### Démarrer vscode
 
 Si vous n'avez pas installé VS code et Docker, vous devez les installer au préalable.
 
@@ -217,16 +217,17 @@ Les conventions consensuelles d'usage sont les suivantes :
 Les locutions latines non francisées suivantes seront écrites en italique :
 *ad hoc*, *ad libitum*, *a fortiori*, *a posteriori*, *a posteriori*, *a priori*, *bis*, *grosso modo*, *ibidem*, *idem*, *in extenso*, *in extremis*, *in extenso*, *in extremis*, *in fine*, *infra*, *loc.cit.*, *modus vivendi*, *op.cit.*, *passim*, *quater*, *sic*, *statu quo*, *supra*, *ter*, *via*, *vice versa*.
 
-## Release
+<!-- ## Release
 
 Une release du rapport peut être générée en ajoutant en tag git après un commit.
+
 ```bash
 git commit -am "Update rapport"
 git tag v1.0.0 -m "Release v1.0.0"
 git push origin --tags
 ```
-Pour que github action puisse générer la release il faut donner les droits à github action de créer des releases. Dans les paramètres du repo sous Actions/General/Workflows Permissions, cocher "Read and write permission" puis save.
 
+Pour que GitHub Actions puisse générer la release il faut lui en donner le droit. Pour ce faire, allez sur la page GitHub de votre référentiel, cliquez sur l'entrée de menu Actions et acceptez d'activer la fonctionnalité. -->
 
 ## Technologies utilisées
 


### PR DESCRIPTION
## Dev Container

### Open-source the Docker image

It is essential for transparency and maintainability that the Docker image is open source.

### draw.io issue

It appears that updating the version solves the issue.

### Non-root user in the container

It is better so created files in the workspace from the CLI are not owned by root.

It appears to bring some difficulties for CI as of now.

## Tested setups

- Both Linux Mint 22.1 & WSL2 with Ubuntu 24.04 :
  - natively,
  - via the Dev Container.
- CI, failed :
  - it needs rework, primarily as the artifacts it uses (up to v2) have been deprecated.

## `README.md` : "Clone" via a direct Fork

It is not a good solution to fork the repository for the user, and even not viable if its project is confidential, as it forces to keep the forked repository public. Hence the `README.md` has been updated with a way to copy instead of forking.